### PR TITLE
[theme] Button theme 재 설정 및 Icon Button 스타일 깨짐 현상 해결

### DIFF
--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -1,4 +1,16 @@
-import { Box, Button, Divider, Flex, Heading, Stack, ThemeTypings, useTheme, Wrap, WrapItem } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Heading,
+  Icon,
+  Stack,
+  ThemeTypings,
+  useTheme,
+  Wrap,
+  WrapItem,
+} from '@chakra-ui/react';
 import { FaArrowRight as FaArrowRightIcon } from 'react-icons/fa';
 import { MdOutlineEmail as MdOutlineEmailIcon } from 'react-icons/md';
 import { BrowserRouter, Link } from 'react-router-dom';
@@ -77,9 +89,9 @@ export const WidthIcons = () => {
   return (
     <Flex direction="column" rowGap={10}>
       <Flex columnGap={10}>
-        <Button leftIcon={<MdOutlineEmailIcon />}>Button</Button>
-        <Button rightIcon={<FaArrowRightIcon />}>Button</Button>
-        <Button leftIcon={<MdOutlineEmailIcon />} rightIcon={<FaArrowRightIcon />}>
+        <Button leftIcon={<Icon as={MdOutlineEmailIcon} />}>Button</Button>
+        <Button rightIcon={<Icon as={FaArrowRightIcon} />}>Button</Button>
+        <Button leftIcon={<Icon as={MdOutlineEmailIcon} />} rightIcon={<Icon as={FaArrowRightIcon} />}>
           Button
         </Button>
       </Flex>

--- a/src/components/IconButton/index.stories.tsx
+++ b/src/components/IconButton/index.stories.tsx
@@ -3,6 +3,7 @@ import {
   Divider,
   Flex,
   Heading,
+  Icon,
   IconButton,
   Stack,
   ThemeTypings,
@@ -21,7 +22,7 @@ export default {
 };
 
 export const Default = () => {
-  return <IconButton aria-label="Search database" icon={<FaSearchIcon />} />;
+  return <IconButton aria-label="Search database" icon={<Icon as={FaSearchIcon} />} />;
 };
 
 export const SizeVariant = () => {
@@ -36,17 +37,46 @@ export const SizeVariant = () => {
       {VARIANT_LIST.map((variant) => (
         <Box key={variant}>
           <Heading mb="16px">{variant.toUpperCase()}</Heading>
-          {SIZE_LIST.map((size) => (
+          <Box mb="2">
+            {SIZE_LIST.map((size) => (
+              <IconButton
+                key={size}
+                mr="10px"
+                aria-label="Search database"
+                icon={<Icon as={FaSearchIcon} />}
+                size={size}
+                variant={variant}
+              />
+            ))}
             <IconButton
-              key={size}
-              mr="10px"
               aria-label="Search database"
-              icon={<FaSearchIcon />}
-              size={size}
+              disabled
+              icon={<Icon as={FaSearchIcon} />}
+              size="xs"
               variant={variant}
             />
-          ))}
-          <IconButton aria-label="Search database" disabled icon={<FaSearchIcon />} size="xs" variant={variant} />
+          </Box>
+          <Box>
+            {SIZE_LIST.map((size) => (
+              <IconButton
+                key={size}
+                mr="10px"
+                aria-label="Search database"
+                icon={<Icon as={FaSearchIcon} />}
+                isRound
+                size={size}
+                variant={variant}
+              />
+            ))}
+            <IconButton
+              aria-label="Search database"
+              disabled
+              icon={<Icon as={FaSearchIcon} />}
+              isRound
+              size="xs"
+              variant={variant}
+            />
+          </Box>
         </Box>
       ))}
     </Stack>
@@ -73,12 +103,17 @@ export const ColorScheme = () => {
             bgImage={colorScheme.includes('white') ? 'url("https://bit.ly/2Z4KKcF")' : undefined}
             bgPosition="center"
           >
-            <IconButton aria-label="Search database" colorScheme={colorScheme} icon={<FaSearchIcon />} size="sm" />
+            <IconButton
+              aria-label="Search database"
+              colorScheme={colorScheme}
+              icon={<Icon as={FaSearchIcon} />}
+              size="sm"
+            />
             <IconButton
               aria-label="Search database"
               colorScheme={colorScheme}
               disabled
-              icon={<FaSearchIcon />}
+              icon={<Icon as={FaSearchIcon} />}
               size="xs"
             />
           </Flex>
@@ -92,10 +127,10 @@ export const Loading = () => {
   return (
     <Flex direction="column" rowGap={10}>
       <Flex columnGap={10}>
-        <IconButton aria-label="Search database" icon={<FaSearchIcon />} isLoading />
+        <IconButton aria-label="Search database" icon={<Icon as={FaSearchIcon} />} isLoading />
         <IconButton
           aria-label="Search database"
-          icon={<FaSearchIcon />}
+          icon={<Icon as={FaSearchIcon} />}
           isLoading
           spinner={<BeatLoader size={8} color="white" />}
         />
@@ -116,26 +151,56 @@ export const Anchors = () => {
       {VARIANT_LIST.map((variant) => (
         <Box key={variant}>
           <Heading mb="16px">{variant.toUpperCase()}</Heading>
-          {SIZE_LIST.map((size) => (
+          <Box mb="2">
+            {SIZE_LIST.map((size) => (
+              <IconButton
+                key={size}
+                as="a"
+                mr="10px"
+                aria-label="Search database"
+                href="https://www.naver.com"
+                icon={<Icon as={FaSearchIcon} />}
+                size={size}
+                variant={variant}
+              >
+                dd
+              </IconButton>
+            ))}
             <IconButton
-              key={size}
               as="a"
-              mr="10px"
               aria-label="Search database"
+              disabled
               href="https://www.naver.com"
-              icon={<FaSearchIcon />}
-              size={size}
+              icon={<Icon as={FaSearchIcon} />}
+              size="xs"
               variant={variant}
             />
-          ))}
-          <IconButton
-            as="a"
-            aria-label="Search database"
-            disabled
-            icon={<FaSearchIcon />}
-            size="xs"
-            variant={variant}
-          />
+          </Box>
+          <Box>
+            {SIZE_LIST.map((size) => (
+              <IconButton
+                key={size}
+                as="a"
+                mr="10px"
+                aria-label="Search database"
+                href="https://www.naver.com"
+                icon={<Icon as={FaSearchIcon} />}
+                isRound
+                size={size}
+                variant={variant}
+              />
+            ))}
+            <IconButton
+              as="a"
+              aria-label="Search database"
+              disabled
+              href="https://www.naver.com"
+              icon={<Icon as={FaSearchIcon} />}
+              isRound
+              size="xs"
+              variant={variant}
+            />
+          </Box>
         </Box>
       ))}
     </Stack>
@@ -147,7 +212,13 @@ export const BrowserLink = () => {
     <Flex direction="column" rowGap={10}>
       <BrowserRouter basename="">
         <Box>
-          <IconButton as={Link} aria-label="Search database" icon={<FaSearchIcon />} to="/" variant="outline" />
+          <IconButton
+            as={Link}
+            aria-label="Search database"
+            icon={<Icon as={FaSearchIcon} />}
+            to="/"
+            variant="outline"
+          />
         </Box>
       </BrowserRouter>
     </Flex>

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -1,9 +1,7 @@
 import type { ComponentStyleConfig } from '@chakra-ui/theme';
 
 const Button: ComponentStyleConfig = {
-  baseStyle: {
-    // fontWeight: 600,
-  },
+  baseStyle: {},
   variants: {
     ghost: {},
     outline: {},
@@ -14,19 +12,23 @@ const Button: ComponentStyleConfig = {
   sizes: {
     lg: {
       height: '55px',
-      padding: '0 26px',
+      px: '26px',
+      minW: 14,
     },
     md: {
       height: '48px',
-      padding: '0 24px',
+      px: '24px',
+      minW: 12,
     },
     sm: {
       height: '32px',
-      padding: '0 16px',
+      px: '16px',
+      minW: 8,
     },
     xs: {
       height: '20px',
-      padding: '0 8px',
+      px: '8px',
+      minW: 6,
     },
   },
   defaultProps: {


### PR DESCRIPTION
- 외부 아이콘을 사용할 경우 display: block 되는 현상 해결
  - Icon 컴포넌트로 third-party-library 연결 => display: inline-block
- Icon Button round가 찌그러지는 현상 해결
  - Icon Button은 기본적으로 padding: 0 [code](https://github.com/chakra-ui/chakra-ui/blob/260076e2ac6165c8079c800475b9d7a9ca0f29a2/packages/components/button/src/icon-button.tsx#L45)
  - Chakra theme의  baseStyle, variants, sizes에 설정한 props들은 바로 style에 적용되는것이 아니라, Chakra 컴포넌트 props에 destructing
  - 이럴 경우 padding은 설정은 못 하니, 기본으로 min-width 설정하여 기본 width 크기를 조절했음 [issue](https://github.com/chakra-ui/chakra-ui/issues/4677)
  - 어차피 Button도 한글자부터 나오게 될 경우 크기가 필요 하니 설정해도 상관 없다고 판단

## Issue

- #29 
